### PR TITLE
[CARMAN-218] Improve grammar in Spanish privacy policy

### DIFF
--- a/pages/es/privacypolicy.html
+++ b/pages/es/privacypolicy.html
@@ -26,22 +26,20 @@
             <p>Datos personales tratados para las siguientes finalidades y utilizando los siguientes servicios:</p>
 
             <ul>
-                <li>Gestión de contactos y envío de mensajes</li>
-                <li>Firebase Cloud Messaging</li>
-                <li>Registro y autenticación
+                <li>Gestión de contactos y envío de mensajes:</li>
+                <li>Firebase Cloud Messaging.</li>
+                <li>Registro y autenticación:
                     <ul>
-                        <li>Firebase Authentication</li>
-                        <li>Registro datos personales: apellido(s); dirección de correo electrónico; foto de perfil;
-                            nombre.</li>
+                        <li>Firebase Authentication.</li>
+                        <li>Registro datos personales: apellido(s), dirección de correo electrónico, foto de perfil y nombre.</li>
                     </ul>
                 </li>
-                <li>Test de rendimiento de contenidos y funcionalidades (A/B testing)</li>
-                <li>Firebase Remote Config</li>
-                <li>Hosting e infraestructura de backend
+                <li>Test de rendimiento de contenidos y funcionalidades (A/B testing):</li>
+                <li>Firebase Remote Config.</li>
+                <li>Hosting e infraestructura de backend:
                     <ul>
-                        <li>Firebase Realtime Database</li>
-                        <li>Datos de monitoreo ingresados por el usuario: distintas clases de datos, según se especifica
-                            en la política de privacidad del servicio.</li>
+                        <li>Firebase Realtime Database.</li>
+                        <li>Datos de monitoreo ingresados por el usuario: distintas clases de datos, según se especifica en la política de privacidad del servicio.</li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
This commit corrects punctuation and formatting in the Spanish privacy policy page (`pages/es/privacypolicy.html`) for better readability. It adjusts the list structure by adding colons to headers and ensuring list items end consistently with periods.