### PR TITLE
[CARMAN-218] Correct list formatting in privacy policies

### DIFF
--- a/pages/en/privacypolicy.html
+++ b/pages/en/privacypolicy.html
@@ -25,7 +25,7 @@
             <p>Personal data processed for the following purposes and using the following services:</p>
 
             <ul>
-                <li>Contact management and message sending.</li>
+                <li>Contact management and message sending:</li>
                     <ul>
                         <li>Firebase Cloud Messaging.</li>
                     </ul>

--- a/pages/en/privacypolicy.html
+++ b/pages/en/privacypolicy.html
@@ -26,7 +26,9 @@
 
             <ul>
                 <li>Contact management and message sending.</li>
-                <li>Firebase Cloud Messaging.</li>
+                    <ul>
+                        <li>Firebase Cloud Messaging.</li>
+                    </ul>
                 <li>Registration and authentication:
                     <ul>
                         <li>Firebase Authentication.</li>

--- a/pages/es/privacypolicy.html
+++ b/pages/es/privacypolicy.html
@@ -27,7 +27,9 @@
 
             <ul>
                 <li>Gestión de contactos y envío de mensajes:</li>
-                <li>Firebase Cloud Messaging.</li>
+                    <ul>
+                        <li>Firebase Cloud Messaging.</li>
+                    </ul>
                 <li>Registro y autenticación:
                     <ul>
                         <li>Firebase Authentication.</li>


### PR DESCRIPTION
This PR fixes an indentation issue in the unordered lists within the English and Spanish privacy policy pages. "Firebase Cloud Messaging" is now correctly nested under its parent list item.